### PR TITLE
Add non blocking metrics via InfluxDB

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,14 @@ func main() {
 		hostDetails.InstanceType,
 	)
 
-	routes := NewRoutes(&config)
+	metrics, err := NewMetrics()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	metricsFactory := NewMetricFactory(hostDetails, &config)
+
+	routes := NewRoutes(&config, metrics, &metricsFactory)
 	startErr := http.ListenAndServe(fmt.Sprintf(":%d", port), routes)
 	if startErr != nil {
 		log.Fatal(startErr)

--- a/metric_factory.go
+++ b/metric_factory.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	influxdb "github.com/influxdb/influxdb/client"
+	"time"
+)
+
+const (
+	CACHE_HIT_SERIES             = "CacheHit"
+	CACHE_WAITED_FOR_UPLOAD      = "CacheWaitedForUpload"
+	CACHE_WAITED_FOR_UPLOAD_MISS = "CacheWaitedForUploadMiss"
+	CACHE_UPLOAD                 = "CacheUpload"
+	CACHE_UPLOAD_ERR             = "CacheUploadError"
+	CACHE_TIMEOUT                = "CacheTimeout"
+	CACHE_ERR_REDIRECT           = "CacheErrorRedirect"
+)
+
+type MetricFactory struct {
+	hostDetails *HostDetails
+	proxyConfig *ProxyConfig
+}
+
+func NewMetricFactory(hostDetails *HostDetails, proxyConfig *ProxyConfig) MetricFactory {
+	return MetricFactory{
+		hostDetails: hostDetails,
+		proxyConfig: proxyConfig,
+	}
+}
+
+func (self *MetricFactory) CacheErrorRedirect() *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_ERR_REDIRECT,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+			},
+		},
+	}
+}
+
+func (self *MetricFactory) CacheTimeout(waitDuration time.Duration) *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_TIMEOUT,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+			"waited",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+				waitDuration.Seconds(),
+			},
+		},
+	}
+}
+
+func (self *MetricFactory) CacheUpload(uploadDuration time.Duration, contentLength int64) *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_UPLOAD,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+			"uploadDuration",
+			"contentLength",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+				uploadDuration.Seconds(),
+				contentLength,
+			},
+		},
+	}
+}
+
+func (self *MetricFactory) CacheUploadError(uploadDuration time.Duration, contentLength int64, err error) *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_UPLOAD_ERR,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+			"uploadDuration",
+			"contentLength",
+			"error",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+				uploadDuration.Seconds(),
+				contentLength,
+				err.Error(),
+			},
+		},
+	}
+}
+
+func (self *MetricFactory) WaitedForUpload(time time.Duration) *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_WAITED_FOR_UPLOAD,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+			"waitTime",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+				time.Seconds(),
+			},
+		},
+	}
+}
+
+func (self *MetricFactory) WaitedForUploadMiss(time time.Duration) *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_WAITED_FOR_UPLOAD_MISS,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+			"time",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+				time.Seconds(),
+			},
+		},
+	}
+}
+
+func (self *MetricFactory) CacheHit() *influxdb.Series {
+	return &influxdb.Series{
+		Name: CACHE_HIT_SERIES,
+		Columns: []string{
+			"hostname",
+			"region",
+			"instanceType",
+			"instanceID",
+		},
+		Points: [][]interface{}{
+			{
+				self.hostDetails.Hostname,
+				self.hostDetails.Region,
+				self.hostDetails.InstanceType,
+				self.hostDetails.InstanceID,
+			},
+		},
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	influxdb "github.com/influxdb/influxdb/client"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const SEND_INTERVAL = 30 * time.Second
+
+// Metrics is thread safe and non-blocking (as far as the influx bit goes)
+type Metrics struct {
+	sync.Mutex
+	// True when we have credentials and actually send data to influxdb
+	Active        bool
+	pendingWrites []*influxdb.Series
+
+	// Client responsible for sending metrics _may_ be null if Active is false
+	client *influxdb.Client
+
+	// This always starts as nil (Start should set this value)
+	ticker *time.Ticker
+}
+
+func (self *Metrics) Send(series *influxdb.Series) {
+	if !self.Active {
+		// If we are not actively able to send metrics this is a lock-less no-op
+		return
+	}
+
+	defer self.Unlock()
+	self.Lock()
+
+	self.pendingWrites = append(self.pendingWrites, series)
+}
+
+func (self *Metrics) Start() error {
+	// Safe guard callers which may call this without an active metrics instance.
+	if !self.Active {
+		return fmt.Errorf("Metrics will not send events without valid credentials...")
+	}
+
+	if self.ticker != nil {
+		return fmt.Errorf("Cannot be started more then once!")
+	}
+
+	self.ticker = time.NewTicker(SEND_INTERVAL)
+	log.Printf("Starting periodic sender will send every %s", SEND_INTERVAL)
+	go self.periodicSender(self.ticker)
+	return nil
+}
+
+// This function will loop forever sending metrics.
+func (self *Metrics) periodicSender(ticker *time.Ticker) {
+	tickChan := ticker.C
+	for {
+		select {
+		case <-tickChan:
+			// Fire and forget (though we will log any errors...)
+			go func() {
+				err := self.SendMetrics()
+				if err != nil {
+					log.Printf("Non fatal error while sending metrics", err)
+				}
+			}()
+		}
+	}
+}
+
+// Immediately send metrics... This is intended to be called by the ticker but
+// may also be called directly if you need to synchronously send metrics for
+// some reason...
+func (self *Metrics) SendMetrics() error {
+	// We don't need to be locked for the entire duration if this method only when
+	// we mutate the pending writes.
+	self.Lock()
+	pendingWrites := self.pendingWrites
+	self.pendingWrites = []*influxdb.Series{}
+	self.Unlock()
+
+	log.Printf("Sending %d metrics", len(pendingWrites))
+	return self.client.WriteSeries(pendingWrites)
+}
+
+// Constructs the metrics sender... This will always succeed but only sends
+// metrics if the ININFLUXDB_URL environment variable is set! If the value is
+// set this will log warning (but not panic) if there are errors sending the
+// metrics.
+func NewMetrics() (*Metrics, error) {
+	pendingWrites := []*influxdb.Series{}
+
+	connectionString := os.Getenv("INFLUXDB_URL")
+	if connectionString == "" {
+		log.Printf("INFLUXDB_URL environment variable empty no metrics will be sent")
+		result := &Metrics{
+			Active:        false,
+			pendingWrites: pendingWrites,
+		}
+		return result, nil
+	}
+
+	connectionURL, err := url.Parse(connectionString)
+	if err != nil {
+		return nil, err
+	}
+
+	isSecure := false
+	if strings.Contains(connectionURL.Scheme, "https") {
+		isSecure = true
+	}
+
+	database := connectionURL.Path
+	if database[0:1] == "/" {
+		database = database[1:]
+	}
+
+	password, _ := connectionURL.User.Password()
+
+	influxConfig := &influxdb.ClientConfig{
+		Host:     connectionURL.Host,
+		Username: connectionURL.User.Username(),
+		Password: password,
+		Database: database,
+		IsSecure: isSecure,
+	}
+
+	influxClient, err := influxdb.NewClient(influxConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Successfully configured influxdb")
+	log.Printf(
+		"host=%s user=%s database=%s",
+		influxConfig.Host,
+		influxConfig.Username,
+		influxConfig.Database,
+	)
+
+	result := &Metrics{
+		Active:        true,
+		client:        influxClient,
+		pendingWrites: pendingWrites,
+	}
+
+	// Start metrics writer...
+	err = result.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	influxdb "github.com/influxdb/influxdb/client"
+	"testing"
+)
+
+// This is a fairly lame test which basically ensures that this does not crash
+// under some conditions... While the logic is fairly simple there is zero
+// testing of how it actually works when submitting to influxdb (which would
+// require some additional external deps)
+func TestMetrics(t *testing.T) {
+	metrics, err := NewMetrics()
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics.Send(&influxdb.Series{
+		Name: "testing",
+		Columns: []string{
+			"foo",
+		},
+		Points: [][]interface{}{
+			{
+				"bar",
+			},
+		},
+	})
+}

--- a/test/launch.js
+++ b/test/launch.js
@@ -39,7 +39,6 @@ export default async function(options) {
   server.close();
   opts.port = port;
 
-
   let cmd = [
     `${BUILD_DIR}/${TEST_TARGET}`,
     `--port=${opts.port}`,

--- a/test/proxy_test.js
+++ b/test/proxy_test.js
@@ -110,7 +110,7 @@ suite('proxy', function() {
   });
 
   test('pending request timeout', async () => {
-    let size = 1024 * 1024 * 1;
+    let size = 1024 * 1024 * 50;
     let { key, md5, proxyUrl, uploadResult } = await upload(size);
 
     let firstResponse = await getResponse(proxyUrl);


### PR DESCRIPTION
The metric agent itself requires the INFLUXDB_URL env to be set to
actually send metrics but will fallover to a no-op mode if this is not
set. Currently this includes some very basic metrics:

  - CacheHit
  - CacheMiss
  - Upload (with time and content size)
  - etc..